### PR TITLE
Mismatch in device family

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ In your app’s Expo config (app.json, or app.config.js), make sure that react-n
 - **requestEphemeralUserNotification** (boolean): Enables notifications for the App Clip (see [Apple Developer Docs](https://developer.apple.com/documentation/app_clips/enabling_notifications_in_app_clips))
 - **requestLocationConfirmation** (boolean): Allow App Clip access to location data (see [Apple Developer Docs](https://developer.apple.com/documentation/app_clips/confirming_the_user_s_physical_location))
 - **appleSignin** (boolean): Enable "Sign in with Apple" for the App Clip
+- **applePayMerchantIds** (string[]): Enable Apple Pay capability with provided merchant IDs.
 - **excludedPackages** (string[]): Packages to exclude from autolinking for the App Clip to reduce bundle size (see below).
 
 ## Native capabilities

--- a/example/app.json
+++ b/example/app.json
@@ -26,7 +26,7 @@
     "web": {
       "favicon": "./assets/favicon.png"
     },
-    "plugins": [["../app.plugin.js", { "name": "Example Clip" }]],
+    "plugins": [["../app.plugin.js", { "name": "Example Clip", "applePayMerchantIds": ["merchant.example.com"] }]],
     "extra": {
       "eas": {
         "projectId": "5aa321dd-d382-4fc5-add1-42a3ff1229f9"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "ncu": "bun x npm-check-updates -p bun",
     "build": "bun x tsc --build ./ ./plugin",
-    "dev": "bun x tsc --build ./ ./plugin --watch"
+    "dev": "bun x tsc --build ./ ./plugin --watch",
+    "prepare": "npm run build"
   },
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   ],
   "scripts": {
     "ncu": "bun x npm-check-updates -p bun",
-    "build": "bun x tsc --build ./ ./plugin",
-    "dev": "bun x tsc --build ./ ./plugin --watch",
+    "build": "tsc --build ./ ./plugin",
+    "dev": "tsc --build ./ ./plugin --watch",
     "prepare": "npm run build"
   },
   "keywords": [

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -5,6 +5,7 @@ import { withAppClipEntitlements } from "./withAppClipEntitlements";
 import { withPodfile } from "./withPodfile";
 import { withAppClipPlist } from "./withAppClipPlist";
 import { withXcode } from "./withXcode";
+import { withDeviceFamily } from "@expo/config-plugins/build/ios/DeviceFamily";
 
 const withAppClip: ConfigPlugin<{
   name: string;
@@ -32,6 +33,9 @@ const withAppClip: ConfigPlugin<{
   const targetName = `${IOSConfig.XcodeUtils.sanitizedName(config.name)}Clip`;
 
   config = withPlugins(config, [
+    [
+      withDeviceFamily, config
+    ],
     [
       withConfig,
       {

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -13,6 +13,7 @@ const withAppClip: ConfigPlugin<{
   requestEphemeralUserNotification?: boolean;
   requestLocationConfirmation?: boolean;
   appleSignin?: boolean;
+  applePayMerchantIds?: string[];
   excludedPackages: string[];
 }> = (
   config,
@@ -23,6 +24,7 @@ const withAppClip: ConfigPlugin<{
     requestEphemeralUserNotification,
     requestLocationConfirmation,
     appleSignin = true,
+    applePayMerchantIds,
     excludedPackages,
   }
 ) => {
@@ -39,7 +41,7 @@ const withAppClip: ConfigPlugin<{
         appleSignin,
       },
     ],
-    [withAppClipEntitlements, { targetName, groupIdentifier, appleSignin }],
+    [withAppClipEntitlements, { targetName, groupIdentifier, appleSignin, applePayMerchantIds }],
     [withPodfile, { targetName, excludedPackages }],
     [
       withAppClipPlist,

--- a/plugin/src/lib/getAppClipEntitlements.ts
+++ b/plugin/src/lib/getAppClipEntitlements.ts
@@ -5,9 +5,11 @@ export function getAppClipEntitlements(
   {
     groupIdentifier,
     appleSignin,
+    applePayMerchantIds,
   }: {
     groupIdentifier?: string;
     appleSignin: boolean;
+    applePayMerchantIds?: string[];
   }
 ) {
   const appBundleIdentifier = iosConfig?.bundleIdentifier;
@@ -27,6 +29,9 @@ export function getAppClipEntitlements(
   iosConfig?.associatedDomains &&
     (entitlements["com.apple.developer.associated-domains"] =
       iosConfig.associatedDomains);
+
+  applePayMerchantIds &&
+    (entitlements["com.apple.developer.in-app-payments"] = applePayMerchantIds);
 
   return entitlements;
 }

--- a/plugin/src/withAppClipEntitlements.ts
+++ b/plugin/src/withAppClipEntitlements.ts
@@ -10,7 +10,8 @@ export const withAppClipEntitlements: ConfigPlugin<{
   targetPath: string;
   groupIdentifier: string;
   appleSignin: boolean;
-}> = (config, { targetName, groupIdentifier, appleSignin }) => {
+  applePayMerchantIds?: string[];
+}> = (config, { targetName, groupIdentifier, appleSignin, applePayMerchantIds }) => {
   return withInfoPlist(config, (config) => {
     const targetPath = path.join(
       config.modRequest.platformProjectRoot,
@@ -21,6 +22,7 @@ export const withAppClipEntitlements: ConfigPlugin<{
     const appClipEntitlements = getAppClipEntitlements(config.ios, {
       groupIdentifier,
       appleSignin,
+      applePayMerchantIds,
     });
 
     fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/plugin/src/withConfig.ts
+++ b/plugin/src/withConfig.ts
@@ -10,9 +10,10 @@ export const withConfig: ConfigPlugin<{
   targetName: string;
   groupIdentifier?: string;
   appleSignin: boolean;
+  applePayMerchantIds?: string[];
 }> = (
   config,
-  { bundleIdentifier, targetName, groupIdentifier, appleSignin }
+  { bundleIdentifier, targetName, groupIdentifier, appleSignin, applePayMerchantIds }
 ) => {
   let configIndex: null | number = null;
   config.extra?.eas?.build?.experimental?.ios?.appExtensions?.forEach(
@@ -58,6 +59,7 @@ export const withConfig: ConfigPlugin<{
       ...appClipConfig.entitlements,
       ...getAppClipEntitlements(config.ios, {
         appleSignin,
+        applePayMerchantIds,
         // groupIdentifier, // Throws an error in EAS
       }),
     };


### PR DESCRIPTION
Fixes #24 
This PR extends https://github.com/bndkt/react-native-app-clip/pull/31

Both base app and app clip need to have the same device family. 


