### PR TITLE
Excluded Packages Fix

### DIFF
--- a/plugin/src/cliPlugin.ts
+++ b/plugin/src/cliPlugin.ts
@@ -1,0 +1,51 @@
+function isValidRNDependency(config: any) {
+  return (
+    Object.keys(config.platforms).filter((key) =>
+      Boolean(config.platforms[key])
+    ).length !== 0
+  );
+}
+function filterConfig(config: any) {
+  const filtered = {
+    ...config,
+  };
+  Object.keys(filtered.dependencies).forEach((item) => {
+    if (!isValidRNDependency(filtered.dependencies[item])) {
+      delete filtered.dependencies[item];
+    }
+  });
+  return filtered;
+}
+
+function plugin(
+  argv: Array<string>,
+  config: {
+    dependencies: {
+      [key: string]: Function;
+    };
+  },
+  args: {
+    exclude?: string[];
+  }
+) {
+  const dependencies = Object.fromEntries(
+    Object.entries(config.dependencies).filter(
+      ([key]) => args.exclude && !args.exclude.includes(key)
+    )
+  );
+  config.dependencies = dependencies;
+
+  console.log(JSON.stringify(filterConfig(config), null, 2));
+}
+
+function parseExclude(value?: string) {
+  return value?.split(",") ?? [];
+}
+
+export const commands = [
+  {
+    name: "app-clip",
+    func: plugin,
+    options: [{ name: "--exclude <exclude>", parse: parseExclude }],
+  },
+];

--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -20,16 +20,17 @@ const getUseNativeModulesAppClip = (excludedPackages: string[] | undefined) => {
   );
 
   if (excludedPackages && excludedPackages.length > 0) {
-    const srcCommand = `["node", cli_bin, "config"]`;
+    const srcCommands = [`["node", cli_bin, "config"]`, `["node", cli_bin, "config", '--platform', 'ios']`];
     // Uses `cliPlugin.ts` to filter package.json
     const newSrcCommand = `["node", cli_bin, "app-clip", "--exclude", "${excludedPackages.join(
       ","
     )}"]`;
-    if(!nativeModulesContent.includes(srcCommand)) {
-        throw new Error(`Failed to find the command to replace in the native modules file. Expected to find "${srcCommand}"`);
+    const validSrcCommand = srcCommands.find((srcCommand) => nativeModulesContent.includes(srcCommand));
+    if(!validSrcCommand) {
+        throw new Error(`Failed to find the command to replace in the native modules file.`);
     }
     nativeModulesContent = nativeModulesContent.replace(
-      srcCommand,
+      validSrcCommand,
       newSrcCommand
     );
   }

--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 
 /**
  * `use_native_modules` is mocked out for `use_native_modules_app_clip` which includes an exclusion of excludedPackages
+ * 
+ * WARNING: This is very likely to break in a future version of React Native. `use_native_modules` is being moved to the `react-native` package.
  */
 const getUseNativeModulesAppClip = (excludedPackages: string[] | undefined) => {
   const nativeModulesPath = require.resolve(
@@ -18,7 +20,7 @@ const getUseNativeModulesAppClip = (excludedPackages: string[] | undefined) => {
   );
 
   if (excludedPackages && excludedPackages.length > 0) {
-    const srcCommand = `["node", cli_bin, "config", '--platform', 'ios']`;
+    const srcCommand = `["node", cli_bin, "config"]`;
     // Uses `cliPlugin.ts` to filter package.json
     const newSrcCommand = `["node", cli_bin, "app-clip", "--exclude", "${excludedPackages.join(
       ","

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,1 @@
+module.exports = require("./plugin/build/cliPlugin");


### PR DESCRIPTION
# Problem
Excluded packages doesn't work (#27) for certain packages.

`use_expo_modules(exclude: ...)` handles unlinking Expo modules using the same underlying functionality as [autolinking exclude](https://docs.expo.dev/modules/autolinking/#exclude). However, from my experimentation, this doesn't affect certain, non-Expo-module packages. This pull request steals code from an older version of this package before [this commit](https://github.com/bndkt/react-native-app-clip/commit/7487d249abdf6f55316144ac53c10a34f21cae6b) to steal and modify `@react-native-community/cli-platform-ios/native_modules.rb`. Kudos to @bndkt for putting together the original solution!

# Concerns
I'm hesitant on whether this pull request should be merged into the library considering how hacky it is. Depending on the version of `@react-native-community/cli-platform-ios`, the replacement breaks (I used 13.6.6 and 14.0.0 when writing and testing this PR). Additionally, it seems that the autolinking functionality is being moved into the core React Native library instead of relying on `@react-native-community/cli-platform-ios`. In the future, this fix will break and this solution will have to be reworked for [`autolinking.rb`](https://github.com/facebook/react-native/blob/8d4fd0746923ceb158e2044f7eda282ae3a9d094/packages/react-native/scripts/cocoapods/autolinking.rb). 