### PR TITLE
Fixing Entitlements

### DIFF
--- a/plugin/src/withConfig.ts
+++ b/plugin/src/withConfig.ts
@@ -68,6 +68,7 @@ export const withConfig: ConfigPlugin<{
       //   config.ios?.entitlements ?? {},
       //   groupIdentifier,
       // ),
+      ...config.ios?.entitlements,
       "com.apple.developer.associated-appclip-app-identifiers": [
         `$(AppIdentifierPrefix)${bundleIdentifier}`,
       ],


### PR DESCRIPTION
There's currently an issue in which any entitlements configured in `app.json`'s `expo.ios.entitlements` gets overwritten. This PR keeps existing entitlements while still adding the app clip identifier entitlement. 

## Test Plan
Works with empty `entitlements` config and existing `entitlements` config. Verified manually by looking at `*.entitlements` file.