### PR TITLE
Excluded Packages Fix

### DIFF
--- a/plugin/src/cliPlugin.ts
+++ b/plugin/src/cliPlugin.ts
@@ -20,5 +20,10 @@ export const run = async (
 		}
 	}
 
+	// Removing excluded packages
+	for (const packageName of exclude) {
+		delete config.dependencies[packageName];
+	}
+
 	console.log(JSON.stringify(config));
 };

--- a/plugin/src/cliPlugin.ts
+++ b/plugin/src/cliPlugin.ts
@@ -1,0 +1,24 @@
+export const run = async (
+	config: {
+		dependencies: Record<string, object>;
+	},
+	exclude: string[],
+) => {
+	// Validation
+	if (typeof config !== "object") {
+		throw new Error("config must be an object");
+	}
+	if (!config.dependencies) {
+		throw new Error("config must have a dependencies key");
+	}
+	if (!Array.isArray(exclude)) {
+		throw new Error("exclude must be an array");
+	}
+	for (const packageName of exclude) {
+		if (typeof packageName !== "string") {
+			throw new Error("exclude must be an array of strings");
+		}
+	}
+
+	console.log(JSON.stringify(config));
+};

--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -49,6 +49,7 @@ target '${targetName}' do
     ]
     exit(status.exitstatus)
   end
+
   # \`react-native-app-clip\` resolves to react-native-app-clip/build/index.js
   clip_command = [
     'node',
@@ -56,6 +57,8 @@ target '${targetName}' do
     '--eval',
     'require(require.resolve(\\'react-native-app-clip\\')+\\'/../../plugin/build/cliPlugin.js\\').run(' + json + ', [${(excludedPackages ?? []).map((packageName) => `"${packageName}"`).join(", ")}])'
   ]
+  json, _, status = Pod::Executable.capture_command(clip_command[0], clip_command[1..], capture: :both)
+  print json
 
   config = use_native_modules!(clip_command)
 

--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -57,8 +57,6 @@ target '${targetName}' do
     '--eval',
     'require(require.resolve(\\'react-native-app-clip\\')+\\'/../../plugin/build/cliPlugin.js\\').run(' + json + ', [${(excludedPackages ?? []).map((packageName) => `"${packageName}"`).join(", ")}])'
   ]
-  json, _, status = Pod::Executable.capture_command(clip_command[0], clip_command[1..], capture: :both)
-  print json
 
   config = use_native_modules!(clip_command)
 

--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -40,7 +40,24 @@ target '${targetName}' do
       'ios'
     ]
   end
-  config = use_native_modules!(config_command)
+
+  # Running the command in the same manner as \`use_react_native\` then running that result through our cliPlugin
+  json, _, status = Pod::Executable.capture_command(config_command[0], config_command[1..], capture: :both)
+  if not status.success?
+    Pod::UI.warn "The command: '#{config_command.join(" ").bold.yellow}' returned a status code of #{status.exitstatus.to_s.bold.red}", [
+        "App Clip autolinking failed. Please ensure autolinking works correctly for the main app target and try again.",
+    ]
+    exit(status.exitstatus)
+  end
+  # \`react-native-app-clip\` resolves to react-native-app-clip/build/index.js
+  clip_command = [
+    'node',
+    '--no-warnings',
+    '--eval',
+    'require(require.resolve(\\'react-native-app-clip\\')+\\'/../../plugin/build/cliPlugin.js\\').run(' + json + ', [${(excludedPackages ?? []).map((packageName) => `"${packageName}"`).join(", ")}])'
+  ]
+
+  config = use_native_modules!(clip_command)
 
   use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
   use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']


### PR DESCRIPTION
Fixes #27

Currently, excluding packages only works for Expo modules. Expo Modules are autolinked using `use_expo_modules` for which an `exclude` parameter exists. For other dependencies, we need to remove the dependencies from the output of `config_command` (which uses either `@react-native-community/cli` or `expo-modules-autolinking`). This PR introduces `cliPlugin.js` which parses the config output from either of the above commands and removes any excluded packages.