### PR TITLE
Propagate Apple Team ID through to AppClip target

### DIFF
--- a/plugin/src/withXcode.ts
+++ b/plugin/src/withXcode.ts
@@ -31,6 +31,7 @@ export const withXcode: ConfigPlugin<{
       currentProjectVersion: config.ios?.buildNumber || "1",
       bundleIdentifier,
       deploymentTarget,
+      appleTeamId: config.ios?.appleTeamId,
     });
 
     const productFile = addProductFile(xcodeProject, {

--- a/plugin/src/xcode/addXCConfigurationList.ts
+++ b/plugin/src/xcode/addXCConfigurationList.ts
@@ -8,12 +8,14 @@ export function addXCConfigurationList(
     currentProjectVersion,
     bundleIdentifier,
     deploymentTarget,
+    appleTeamId,
   }: {
     name: string;
     targetName: string;
     currentProjectVersion: string;
     bundleIdentifier: string;
     deploymentTarget: string;
+    appleTeamId?: string;
   },
 ) {
   const commonBuildSettings: Record<string, string> = {
@@ -30,6 +32,7 @@ export function addXCConfigurationList(
     VERSIONING_SYSTEM: `"apple-generic"`,
     // TARGETED_DEVICE_FAMILY: `"1,2"`,
     CODE_SIGN_ENTITLEMENTS: `${targetName}/${targetName}.entitlements`,
+    ...(appleTeamId ? { DEVELOPMENT_TEAM: appleTeamId } : {}),
   };
 
   const buildConfigurationsList = [


### PR DESCRIPTION
If `ios.appleTeamId` is defined in app.json / app.config.js, it is now propagated to the Clip target too. Previously the developer would need to manually set the Signing Team in Xcode > Signing & Capabilities.