### PR TITLE
fix(plugin): pass excludedPackages to cliPlugin

### DIFF
--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -19,6 +19,10 @@ export const withPodfile: ConfigPlugin<{
         excludedPackages && excludedPackages.length > 0
           ? `exclude = ["${excludedPackages.join(`", "`)}"]\n  use_expo_modules!(exclude: exclude)`
           : "use_expo_modules!";
+      const excludedPackagesArg =
+        excludedPackages && excludedPackages.length > 0
+          ? JSON.stringify(excludedPackages)
+          : "[]";
 
       const appClipTarget = `
 # @generated begin react-native-app-clip
@@ -52,7 +56,7 @@ target '${targetName}' do
     'node',
     '--no-warnings',
     '--eval',
-    'require(require.resolve(\\'react-native-app-clip\\')+\\'/../../plugin/build/cliPlugin.js\\').run(' + json + ', [])'
+    'require(require.resolve(\\'react-native-app-clip\\')+\\'/../../plugin/build/cliPlugin.js\\').run(' + json + ', ${excludedPackagesArg})'
   ]
 
   config = use_native_modules!(clip_command)


### PR DESCRIPTION
## Summary

`withPodfile` already accepts `excludedPackages` and passes them to `use_expo_modules!(exclude: ...)`, but the same exclude list is not passed to `cliPlugin.js`.

As a result, React Native community/native dependencies are still autolinked into the App Clip target even when they are listed in `excludedPackages`.

## What this changes

This PR passes the actual `excludedPackages` array into:

```js
require(.../cliPlugin.js).run(json, excludedPackages)
```

instead of always calling:

```js
run(json, [])
```

## Why this matters

`cliPlugin.js` already supports removing excluded dependencies from `config.dependencies`, but `withPodfile` was not wiring that through.

Without this fix, packages such as these can still be linked into the App Clip target:

- `react-native-reanimated`
- `react-native-worklets`
- `@react-native-google-signin/google-signin`

## Reproduction

1. Configure `react-native-app-clip` with `excludedPackages`
2. Add one or more React Native community/native packages
3. Run `expo prebuild -p ios`
4. Inspect the generated `ios/Podfile`

Before this fix, the generated `clip_command` still uses:

```js
run(' + json + ', [])
```

After this fix, it uses the provided excluded package list.
